### PR TITLE
#2 Fixed world is null, using EMI mod

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.20.1+build.9
 loader_version=0.14.21
 
 # Mod Properties
-mod_version=1.0.0
+mod_version=1.0.1
 maven_group=dorkix.mods
 archives_base_name=netherite_compass
 

--- a/src/client/java/dorkix/mods/NetheriteCompassModClient.java
+++ b/src/client/java/dorkix/mods/NetheriteCompassModClient.java
@@ -22,7 +22,7 @@ public class NetheriteCompassModClient implements ClientModInitializer {
 		ModelPredicateProviderRegistry.register(NetheriteCompassMod.NETHERITE_COMPASS, new Identifier("angle"),
 				(stack, world, entity, i) -> {
 					var pos = NetheriteCompass.getTrackedPos(stack.getNbt());
-					if (pos == null) {
+					if (pos == null && world != null) {
 						return getSpinningAngle(world);
 					}
 


### PR DESCRIPTION
This fixes the crash caused by the EMI mod, where the world is not set when calling the ModelPredicateProvider callback.